### PR TITLE
Fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 `xcover-python` is available on PyPI. To install the latest version run:
 
-    pip install xcover
+    pip install xcover-python
 
 or
 
-    poertry install xcover
+    poertry install xcover-python
 
 ## Features
 


### PR DESCRIPTION
Found a typo in the README file: the PIP package name is incorrect in the README description.

**Expected**:
`pip install xcover-python`

**Actual**:
`pip install xcover` 