### PR TITLE
Ensure that xcover client uses REQUESTS_CA_BUNDLE

### DIFF
--- a/xcover/xcover.py
+++ b/xcover/xcover.py
@@ -64,8 +64,10 @@ class XCover:
             auth=XCoverAuth(self.config.auth_config),
             headers={**self.default_headers, **headers},
         )
+
         prepared_request: requests.PreparedRequest = session.prepare_request(request)
-        response = session.send(prepared_request, timeout=self.config.http_timeout)
+        settings = session.merge_environment_settings(prepared_request.url, {}, None, None, None)
+        response = session.send(prepared_request, timeout=self.config.http_timeout, **settings)
 
         return response
 


### PR DESCRIPTION
... Along with other requests ENV settings.

See https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests

Here are the steps to help reproduce the issue and show that this solution works.

```
import requests
session = requests.Session()
request = requests.Request('GET', 'https://api.xcover.com/x/', headers={"Content-Type": "application/json"})
prepared_request: requests.PreparedRequest = session.prepare_request(request)

# throws an SSL error (prepared request isn't using ENV vars)
session.send(prepared_request)

# works (non-prepared request)
requests.get('https://api.xcover.com/x/', headers={"Content-Type": "application/json"})

# works w/ prepared request by importing settings from env vars
settings = session.merge_environment_settings(prepared_request.url, {}, None, None, None)
session.send(prepared_request, **settings)
```